### PR TITLE
Add installation method based on Poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "open-imagilib"
+version = "0.1.0"
+description = "Implementation of the imagilib library + ImagiCharm emulator. See https://imagilabs.com/ for the original."
+license = "MIT"
+authors = ["Viktor Ferenczi <viktor@ferenczi.eu>"]
+readme = "README.md"
+repository = "https://github.com/viktor-ferenczi/open-imagilib"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+opencv-python = ">=4.0"
+imageio = ">=2.0"
+numpy = ">=1.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Thank you for creating your open source project!

The project lacked an installation method. Poetry is a modern and widely used tool to manage Python projects and their dependencies.

It allows to install open-imagilib using pip. Specification of a version number was required, so the default for new Poetry projects (0.1.0) was chosen.

You can now create a venv by running "poetry install" once and enter it using "poetry shell". Example programs can then be run without setting any environment variables manually.

For more information about Poetry see https://python-poetry.org/.